### PR TITLE
✨ Hierarchical project reference support for OmniFocus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ go.work.sum
 
 # Built binaries
 build/
+/omnidrop-server
 
 # env file
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,17 @@ TOKEN="your-secret-token" ./omnidrop-server
 # Run with custom port
 PORT=8080 TOKEN="your-secret-token" ./omnidrop-server
 
-# Test the API endpoint
+# Test the API endpoint with simple project name
 curl -X POST http://localhost:8787/tasks \
   -H "Authorization: Bearer your-secret-token" \
   -H "Content-Type: application/json" \
   -d '{"title":"Test Task","note":"Description","project":"Work","tags":["urgent"]}'
+
+# Test with hierarchical project path
+curl -X POST http://localhost:8787/tasks \
+  -H "Authorization: Bearer your-secret-token" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Test Task","note":"Description","project":"Getting Things Done/3. Projects/お仕事/Enablement","tags":["urgent"]}'
 ```
 
 ## Configuration
@@ -56,7 +62,7 @@ Request body:
 {
   "title": "string (required)",
   "note": "string (optional)",
-  "project": "string (optional)",
+  "project": "string (optional) - supports hierarchical paths",
   "tags": ["string array (optional)"]
 }
 ```
@@ -76,5 +82,7 @@ Response:
 - Authentication is mandatory via `Authorization: Bearer <token>` header
 - AppleScript execution errors are captured and returned in API responses
 - Tasks are automatically assigned today's date at 23:59:59 as due date
+- **Hierarchical Project Support**: Projects can be referenced using paths (e.g., "Getting Things Done/3. Projects/お仕事/Enablement")
+- Simple project names are supported for backward compatibility
 - Project and tag names must exactly match existing items in OmniFocus
 - Tags that don't exist in OmniFocus are silently ignored

--- a/omnidrop.applescript
+++ b/omnidrop.applescript
@@ -1,3 +1,137 @@
+-- String utility functions
+on splitString(inputString, delimiter)
+    set oldDelimiters to AppleScript's text item delimiters
+    set AppleScript's text item delimiters to delimiter
+    set stringList to text items of inputString
+    set AppleScript's text item delimiters to oldDelimiters
+    return stringList
+end splitString
+
+on trimWhitespace(inputString)
+    set trimmedString to inputString
+    -- Remove leading whitespace
+    repeat while trimmedString starts with " " or trimmedString starts with tab
+        if length of trimmedString > 1 then
+            set trimmedString to text 2 thru -1 of trimmedString
+        else
+            set trimmedString to ""
+            exit repeat
+        end if
+    end repeat
+    -- Remove trailing whitespace
+    repeat while trimmedString ends with " " or trimmedString ends with tab
+        if length of trimmedString > 1 then
+            set trimmedString to text 1 thru -2 of trimmedString
+        else
+            set trimmedString to ""
+            exit repeat
+        end if
+    end repeat
+    return trimmedString
+end trimWhitespace
+
+-- Project resolution functions
+on resolveProjectReference(projectPath, targetDocument)
+    if projectPath is "" then
+        return missing value
+    end if
+    
+    try
+        if projectPath contains "/" then
+            return my resolveHierarchicalProject(projectPath, targetDocument)
+        else
+            return my resolveFlatProject(projectPath, targetDocument)
+        end if
+    on error errMsg
+        error "Project resolution failed: " & errMsg
+    end try
+end resolveProjectReference
+
+on resolveHierarchicalProject(projectPath, targetDocument)
+    set pathComponents to my splitString(projectPath, "/")
+    set projectName to last item of pathComponents
+    
+    -- If only one component, it's just a project name
+    if (count of pathComponents) is 1 then
+        return my resolveFlatProject(projectName, targetDocument)
+    end if
+    
+    set folderComponents to items 1 thru -2 of pathComponents
+    
+    -- Build folder reference chain
+    set currentContainer to targetDocument
+    repeat with folderName in folderComponents
+        set folderName to my trimWhitespace(folderName as string)
+        try
+            tell application "OmniFocus" to set folderList to (every folder of currentContainer whose name is folderName)
+            if (count of folderList) > 0 then
+                set currentContainer to item 1 of folderList
+            else
+                error "Folder not found: " & folderName
+            end if
+        on error errMsg
+            error "Folder navigation failed: " & errMsg
+        end try
+    end repeat
+    
+    -- Find project in target folder
+    try
+        tell application "OmniFocus" to set projectList to (every project of currentContainer whose name is projectName)
+        if (count of projectList) > 0 then
+            return item 1 of projectList
+        else
+            error "Project '" & projectName & "' not found in folder hierarchy"
+        end if
+    on error errMsg
+        error errMsg
+    end try
+end resolveHierarchicalProject
+
+on resolveFlatProject(projectName, targetDocument)
+    -- First try direct project search
+    tell application "OmniFocus" to set projectList to (every project of targetDocument whose name is projectName)
+    if (count of projectList) > 0 then
+        return item 1 of projectList
+    end if
+    
+    -- If not found, search in all folders recursively
+    tell application "OmniFocus"
+        tell targetDocument
+            set allFolders to every folder
+            repeat with aFolder in allFolders
+                set foundProject to my searchProjectInFolder(projectName, aFolder)
+                if foundProject is not missing value then
+                    return foundProject
+                end if
+            end repeat
+        end tell
+    end tell
+    
+    error "Project not found: " & projectName
+end resolveFlatProject
+
+on searchProjectInFolder(projectName, targetFolder)
+    tell application "OmniFocus"
+        -- Check projects in this folder
+        set projectList to (every project of targetFolder whose name is projectName)
+        if (count of projectList) > 0 then
+            return item 1 of projectList
+        end if
+        
+        -- Check subfolders recursively
+        set subFolders to every folder of targetFolder
+        repeat with subFolder in subFolders
+            set foundProject to my searchProjectInFolder(projectName, subFolder)
+            if foundProject is not missing value then
+                return foundProject
+            end if
+        end repeat
+    end tell
+    
+    return missing value
+end searchProjectInFolder
+
+-- Main handler
 on run argv
     -- Check arguments: expecting 4 arguments (title, note, project, tags)
     if (count of argv) < 4 then
@@ -7,7 +141,7 @@ on run argv
     -- Get arguments directly (no parsing needed)
     set taskTitle to item 1 of argv
     set taskNote to item 2 of argv
-    set projectName to item 3 of argv
+    set projectPath to item 3 of argv  -- Now supports hierarchical paths
     set tagsString to item 4 of argv
 
     try
@@ -19,30 +153,29 @@ on run argv
         -- Parse tags from comma-separated string
         set tagsList to {}
         if tagsString is not "" then
-            set oldDelimiters to AppleScript's text item delimiters
-            set AppleScript's text item delimiters to ","
-            set tagsList to text items of tagsString
-            set AppleScript's text item delimiters to oldDelimiters
+            set tagsList to my splitString(tagsString, ",")
         end if
         
         -- Create task in OmniFocus
         tell application "OmniFocus"
             tell default document
-                -- Find project if specified
+                -- Resolve project using new hierarchical system
                 set targetProject to missing value
-                if projectName is not "" then
+                if projectPath is not "" then
                     try
-                        set projectList to (every project whose name is projectName)
-                        if (count of projectList) > 0 then
-                            set targetProject to item 1 of projectList
-                        end if
+                        set docRef to it
+                        set targetProject to my resolveProjectReference(projectPath, docRef)
+                    on error errMsg
+                        -- Log the error but continue (task will go to inbox)
+                        log "Project resolution error: " & errMsg
                     end try
                 end if
                 
-                -- Create task
+                -- Create task with proper project assignment
                 if targetProject is not missing value then
-                    set newTask to make new task with properties {name:taskTitle}
-                    move newTask to end of tasks of targetProject
+                    tell targetProject
+                        set newTask to make new task with properties {name:taskTitle}
+                    end tell
                 else
                     set newTask to make new inbox task with properties {name:taskTitle}
                 end if
@@ -63,7 +196,7 @@ on run argv
                 if (count of tagsList) > 0 then
                     set resolvedTags to {}
                     repeat with tagName in tagsList
-                        set tagName to tagName as text
+                        set tagName to my trimWhitespace(tagName as text)
                         if tagName is not "" then
                             try
                                 set tagList to (every tag whose name is tagName)


### PR DESCRIPTION
## Summary
- Implement hierarchical project path support for OmniFocus GTD structure
- Maintain backward compatibility with simple project names
- Add comprehensive error handling and fallback mechanisms

## Changes
- **Hierarchical Path Support**: Projects can now be referenced using full paths like `"Getting Things Done/3. Projects/お仕事/Enablement"`
- **Backward Compatibility**: Simple project names still work via recursive folder search
- **Smart Resolution**: Automatically falls back to inbox if project not found
- **Japanese Support**: Full support for Japanese folder and project names
- **Utility Functions**: Added `splitString` and `trimWhitespace` for robust string handling

## Test Results
All test scenarios passed successfully:
- ✅ Inbox task creation (no project)
- ✅ Simple project name resolution
- ✅ Full hierarchical path resolution  
- ✅ Japanese project names
- ✅ Tag functionality
- ✅ Error handling with fallback to inbox

## API Usage Examples
```bash
# Simple project name (backward compatible)
curl -X POST http://localhost:8787/tasks \
  -d '{"title":"Task","project":"Enablement"}'

# Hierarchical project path
curl -X POST http://localhost:8787/tasks \
  -d '{"title":"Task","project":"Getting Things Done/3. Projects/お仕事/Enablement"}'
```

## Breaking Changes
None - fully backward compatible

🤖 Generated with [Claude Code](https://claude.ai/code)