### PR TITLE
feat: smart plist update protection and v2.1 documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,12 @@ The system consists of three main components:
 # Build the server
 go build -o omnidrop-server .
 
+# Install to system (LaunchAgent)
+make install
+
+# Install with plist update (creates timestamped backup)
+make install FORCE_PLIST=1
+
 # Run the server (requires TOKEN environment variable)
 TOKEN="your-secret-token" ./omnidrop-server
 
@@ -243,6 +249,36 @@ Projects can be referenced using paths (e.g., "Getting Things Done/3. Projects/ã
    - `PORT` should be 8788-8799 range
    - `OMNIDROP_SCRIPT` should point to development AppleScript
 
+### Installation and Updates
+
+**Initial Installation:**
+```bash
+# First-time installation
+make install
+```
+
+**Updating Without Plist Changes:**
+```bash
+# Updates binary and AppleScript, preserves existing plist configuration
+make install
+```
+
+**Updating With Plist Changes:**
+```bash
+# Force plist update (creates timestamped backup automatically)
+make install FORCE_PLIST=1
+```
+
+**Plist Update Behavior:**
+- **Default (`make install`)**: Skips plist if it already exists, preserving custom settings
+- **Force mode (`FORCE_PLIST=1`)**: Updates plist with automatic backup to `~/Library/LaunchAgents/com.oshiire.omnidrop.plist.backup.YYYYMMDD_HHMMSS`
+- **New installation**: Always creates plist from template
+
+**Manual Plist Backup:**
+```bash
+cp ~/Library/LaunchAgents/com.oshiire.omnidrop.plist ~/Library/LaunchAgents/com.oshiire.omnidrop.plist.backup
+```
+
 ### Troubleshooting
 
 **If tags are not being assigned:**
@@ -254,3 +290,8 @@ Projects can be referenced using paths (e.g., "Getting Things Done/3. Projects/ã
 1. Run `make test-preflight` to check environment safety
 2. Verify no production processes are running on port 8787
 3. Check that OmniFocus is accessible for AppleScript execution
+
+**If `make install` reports plist is skipped:**
+1. This is normal behavior to protect your custom settings
+2. To update plist with new TOKEN or settings: `make install FORCE_PLIST=1`
+3. Check backup files: `ls -la ~/Library/LaunchAgents/com.oshiire.omnidrop.plist.backup.*`

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"omnidrop/internal/observability"
 )
 
 func TestNew(t *testing.T) {
@@ -139,6 +141,10 @@ func TestApplication_DisplayStartupInfo(t *testing.T) {
 	}()
 
 	app := NewWithVersion("1.0.0", "2025-09-15")
+
+	// Setup logger (required for displayStartupInfo)
+	app.logger = observability.SetupLogger()
+
 	err := app.initialize()
 	if err != nil {
 		t.Fatalf("initialize() failed: %v", err)
@@ -160,6 +166,10 @@ func TestApplication_PerformHealthChecks(t *testing.T) {
 	}()
 
 	app := New()
+
+	// Setup logger (required for performHealthChecks)
+	app.logger = observability.SetupLogger()
+
 	err := app.initialize()
 	if err != nil {
 		t.Fatalf("initialize() failed: %v", err)
@@ -181,6 +191,10 @@ func TestApplication_Shutdown(t *testing.T) {
 	}()
 
 	app := New()
+
+	// Setup logger (required for shutdown)
+	app.logger = observability.SetupLogger()
+
 	err := app.initialize()
 	if err != nil {
 		t.Fatalf("initialize() failed: %v", err)
@@ -206,6 +220,9 @@ func TestApplication_Lifecycle(t *testing.T) {
 	}()
 
 	app := New()
+
+	// Setup logger (required for displayStartupInfo, performHealthChecks)
+	app.logger = observability.SetupLogger()
 
 	// Test initialization
 	err := app.initialize()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,6 +9,7 @@ import (
 
 	"omnidrop/internal/config"
 	"omnidrop/internal/handlers"
+	"omnidrop/internal/observability"
 	"omnidrop/test/mocks"
 )
 
@@ -21,8 +22,8 @@ func TestNewServer(t *testing.T) {
 	mockOmniFocusService := &mocks.MockOmniFocusService{}
 	mockFilesService := &mocks.MockFilesService{}
 	h := handlers.New(cfg, mockOmniFocusService, mockFilesService)
-
-	server := NewServer(cfg, h)
+	logger := observability.SetupLogger()
+	server := NewServer(cfg, h, logger)
 
 	if server == nil {
 		t.Fatal("NewServer returned nil")
@@ -54,7 +55,8 @@ func TestServer_GetAddress(t *testing.T) {
 	mockOmniFocusService := &mocks.MockOmniFocusService{}
 	mockFilesService := &mocks.MockFilesService{}
 	h := handlers.New(cfg, mockOmniFocusService, mockFilesService)
-	server := NewServer(cfg, h)
+	logger := observability.SetupLogger()
+	server := NewServer(cfg, h, logger)
 
 	expectedAddr := ":8788"
 	actualAddr := server.GetAddress()
@@ -73,7 +75,8 @@ func TestServer_GetRouter(t *testing.T) {
 	mockOmniFocusService := &mocks.MockOmniFocusService{}
 	mockFilesService := &mocks.MockFilesService{}
 	h := handlers.New(cfg, mockOmniFocusService, mockFilesService)
-	server := NewServer(cfg, h)
+	logger := observability.SetupLogger()
+	server := NewServer(cfg, h, logger)
 
 	router := server.GetRouter()
 	if router == nil {
@@ -90,7 +93,8 @@ func TestServer_RouteConfiguration(t *testing.T) {
 	mockOmniFocusService := &mocks.MockOmniFocusService{}
 	mockFilesService := &mocks.MockFilesService{}
 	h := handlers.New(cfg, mockOmniFocusService, mockFilesService)
-	server := NewServer(cfg, h)
+	logger := observability.SetupLogger()
+	server := NewServer(cfg, h, logger)
 
 	router := server.GetRouter()
 
@@ -150,7 +154,8 @@ func TestServer_MiddlewareConfiguration(t *testing.T) {
 	mockOmniFocusService := &mocks.MockOmniFocusService{}
 	mockFilesService := &mocks.MockFilesService{}
 	h := handlers.New(cfg, mockOmniFocusService, mockFilesService)
-	server := NewServer(cfg, h)
+	logger := observability.SetupLogger()
+	server := NewServer(cfg, h, logger)
 
 	router := server.GetRouter()
 
@@ -182,7 +187,8 @@ func TestServer_HTTPServerConfiguration(t *testing.T) {
 	mockOmniFocusService := &mocks.MockOmniFocusService{}
 	mockFilesService := &mocks.MockFilesService{}
 	h := handlers.New(cfg, mockOmniFocusService, mockFilesService)
-	server := NewServer(cfg, h)
+	logger := observability.SetupLogger()
+	server := NewServer(cfg, h, logger)
 
 	// Check HTTP server configuration
 	if server.httpSrv.Addr != ":8788" {
@@ -215,7 +221,8 @@ func TestServer_Shutdown(t *testing.T) {
 	mockOmniFocusService := &mocks.MockOmniFocusService{}
 	mockFilesService := &mocks.MockFilesService{}
 	h := handlers.New(cfg, mockOmniFocusService, mockFilesService)
-	server := NewServer(cfg, h)
+	logger := observability.SetupLogger()
+	server := NewServer(cfg, h, logger)
 
 	// Test shutdown with context
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -237,7 +244,8 @@ func TestServer_Integration(t *testing.T) {
 	mockOmniFocusService := &mocks.MockOmniFocusService{}
 	mockFilesService := &mocks.MockFilesService{}
 	h := handlers.New(cfg, mockOmniFocusService, mockFilesService)
-	server := NewServer(cfg, h)
+	logger := observability.SetupLogger()
+	server := NewServer(cfg, h, logger)
 
 	// Test that the server can be used with httptest.Server
 	testServer := httptest.NewServer(server.GetRouter())


### PR DESCRIPTION
## Summary
Implements smart plist update protection to preserve user custom settings during installation, and updates all documentation to reflect v2.1 features.

## Changes

### 🔧 Smart Plist Update Protection
**Problem**: `make install` unconditionally overwrites LaunchAgent plist, destroying user customizations (PORT, environment variables, ThrottleInterval, etc.)

**Solution**: 
- **Default behavior**: Skips existing plist to preserve custom settings
- **Force update**: `make install FORCE_PLIST=1` updates plist with automatic timestamped backup
- **New installation**: Always creates plist from template

**Implementation** ([Makefile](Makefile#L89-L129)):
- Existence check before plist installation
- Automatic backup with `YYYYMMDD_HHMMSS` timestamp format
- Clear user guidance messages for next actions
- Preserves user workflow: `make install` for normal updates, `FORCE_PLIST=1` when needed

**Documentation** ([CLAUDE.md](CLAUDE.md#L252-L297)):
- Installation and update workflows
- Plist update behavior explanation
- Troubleshooting guide for plist skipping

### 📝 Comprehensive Documentation Update
Updates README.md to reflect all v2.1 features:

**Features Section Reorganization**:
- Core Functionality (dual API, security features)
- Integration & Operations (Prometheus, logging, configuration)
- Service Management (lifecycle, smart updates, testing)

**New Documentation**:
- Files API endpoint reference with curl examples
- Prometheus metrics endpoint and usage
- `OMNIDROP_FILES_DIR` environment variable
- Smart plist update with `FORCE_PLIST` flag
- Security considerations for file operations

**Updates**:
- Installation instructions with plist protection behavior
- v2.1 Recent Improvements section
- Updated acknowledgments with new dependencies (go-chi, Prometheus, slog-http)

## File Changes
- `Makefile`: +34 lines (smart plist logic)
- `CLAUDE.md`: +43 lines (installation guide)
- `README.md`: +132 lines (comprehensive feature documentation)

## Testing Checklist
- [x] Default install preserves existing plist
- [x] FORCE_PLIST=1 creates timestamped backup
- [x] New installation creates plist normally
- [x] Documentation accurately reflects behavior
- [x] All curl examples are valid

## Related PRs
- Built on top of #11 (Prometheus metrics)
- Addresses plist overwrite issue from installation workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>