### PR TITLE
refactor: remove unused logger context helpers and unused mocks

### DIFF
--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -1,7 +1,6 @@
 package observability
 
 import (
-	"context"
 	"io"
 	"log/slog"
 	"os"
@@ -122,21 +121,3 @@ func slogLevel(level LogLevel) slog.Level {
 	}
 }
 
-// contextKey is a private type for context keys defined in this package to avoid collisions.
-type contextKey string
-
-const contextKeyLogger contextKey = "logger"
-
-// WithRequestID adds a request ID to the logger context
-func WithRequestID(ctx context.Context, requestID string) context.Context {
-	logger := slog.With("request_id", requestID)
-	return context.WithValue(ctx, contextKeyLogger, logger)
-}
-
-// LoggerFromContext retrieves the logger from context, falling back to default
-func LoggerFromContext(ctx context.Context) *slog.Logger {
-	if logger, ok := ctx.Value(contextKeyLogger).(*slog.Logger); ok {
-		return logger
-	}
-	return slog.Default()
-}

--- a/test/mocks/services.go
+++ b/test/mocks/services.go
@@ -21,51 +21,6 @@ func (m *MockOmniFocusService) CreateTask(ctx context.Context, req services.Task
 	}
 }
 
-// MockAppleScriptExecutor provides a mock implementation for testing
-type MockAppleScriptExecutor struct {
-	ExecuteFunc       func(ctx context.Context, script string, args ...string) ([]byte, error)
-	ExecuteSimpleFunc func(ctx context.Context, script string) ([]byte, error)
-}
-
-func (m *MockAppleScriptExecutor) Execute(ctx context.Context, script string, args ...string) ([]byte, error) {
-	if m.ExecuteFunc != nil {
-		return m.ExecuteFunc(ctx, script, args...)
-	}
-	return []byte("mock_success"), nil
-}
-
-func (m *MockAppleScriptExecutor) ExecuteSimple(ctx context.Context, script string) ([]byte, error) {
-	if m.ExecuteSimpleFunc != nil {
-		return m.ExecuteSimpleFunc(ctx, script)
-	}
-	return []byte("mock_simple_success"), nil
-}
-
-// MockHealthService provides a mock implementation for testing
-type MockHealthService struct {
-	CheckAppleScriptHealthFunc func() services.HealthResult
-	CheckOmniFocusStatusFunc   func() bool
-}
-
-func (m *MockHealthService) CheckAppleScriptHealth() services.HealthResult {
-	if m.CheckAppleScriptHealthFunc != nil {
-		return m.CheckAppleScriptHealthFunc()
-	}
-	return services.HealthResult{
-		AppleScriptAccessible: true,
-		OmniFocusRunning:      true,
-		ScriptPath:            "/mock/path/omnidrop.applescript",
-		Details:               "Mock health check successful",
-	}
-}
-
-func (m *MockHealthService) CheckOmniFocusStatus() bool {
-	if m.CheckOmniFocusStatusFunc != nil {
-		return m.CheckOmniFocusStatusFunc()
-	}
-	return true
-}
-
 // MockFilesService provides a mock implementation for testing
 type MockFilesService struct {
 	WriteFileFunc func(ctx context.Context, req services.FileWriteRequest) services.FileWriteResponse


### PR DESCRIPTION
## Summary
- Drop `WithRequestID` / `LoggerFromContext` from `internal/observability/logger.go` — neither helper has any callers in the codebase.
- Drop `MockAppleScriptExecutor` / `MockHealthService` from `test/mocks/services.go` — both are unreferenced.

Net change: 64 lines removed, no behavior change.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `grep` confirms no remaining references to removed symbols